### PR TITLE
introduce LRT functionality to wald()

### DIFF
--- a/R/wald.R
+++ b/R/wald.R
@@ -369,7 +369,7 @@ wald <-
           mlfit <- update(fit, REML = FALSE)     # refit both models using 'ML' for proper comparison
           formulalmer <- formula(fit)
           formulalmer <- paste(deparse(formulalmer, width.cutoff = 500), collapse="")
-          formind <- gregexpr("\\({1}?[^\\(|\\||\\)]*\\|{,2}[^//)]*[\\)]{1}?", formulalmer)[[1]]
+          formind <- gregexpr("\\({1}?[^\\(|\\||\\)]*\\|{1,2}[^//)]*[\\)]{1}?", formulalmer)[[1]]
           lengs <- attr(formind, which = "match.length")
           ranEffects <- substring(formulalmer, first = formind, last = formind + lengs - 1)
           constrained_fit <- update(fit, as.formula(paste0(". ~ ", paste(names1, collapse = "+"),  

--- a/R/wald.R
+++ b/R/wald.R
@@ -316,28 +316,49 @@ wald <-
                               "Wald p-value" = pf(Fstat, numDF, denDF, lower.tail = FALSE))
       ## LRT
       if (LRT) {
-        if ( class(fit) %in% c("lme", "lm", "glm") ) {
+        
+        if ( class(fit) %in% c("lm", "glm") ) {
           model_mat <- getX(fit)
           sv2 <- svd(na.omit(L) , nu = 0, nv = NCOL(L))
           rmv <- if (numDF == 0) 1:NCOL(L) else -(1:numDF)
           constrainedX <- as.matrix(model_mat %*% sv2$v[ , rmv, drop=FALSE])
-          cXnames <- " "
-          for (j in 1:NCOL(constrainedX)){
-            cXnames <- c(cXnames, paste0("cX", j))
-            eval(parse(text = paste0("cX", j, "<- constrainedX[ ,", j, "]")))
-          }
-          constrained_fit <- update(fit, as.formula(paste('. ~ ', paste(cXnames, collapse = "+"), '- 1')), 
-                                    data = eval(parse(text = paste0("data.frame(getData(fit),", 
-                                                                    paste(cXnames[-1], collapse = ","), ")"))))
+          numCol <- NCOL(constrainedX)
+          names1 <- as.character(1:numCol)
+          names1 <- sapply(names1, function(x) paste0("XConCol", x))
+          newData <- data.frame(cbind(constrainedX, getData(fit)))
+          names(newData) <- c(names1, names(getData(fit)))
+          constrained_fit <- update(fit, as.formula(paste0(". ~ ", paste(names1, collapse = "+"),  "- 1")), data = newData)
           changeDF <- NCOL(L) - numDF
           lrt_stat <- 2 * ( logLik(fit) - logLik(constrained_fit) )
           if (lrt_stat < 0) warning("LRT stat is negative, original fit may have convergence problems.")
           ret[[ii]]$anova[["changeDF"]] <- changeDF
           ret[[ii]]$anova[["LRT ChiSq"]] <- lrt_stat
           ret[[ii]]$anova[["LRT p-value"]] <- pchisq(lrt_stat, changeDF, lower.tail = FALSE)
+        
+        } else if ( class(fit) %in% c("lme", "gls") ) {
+          model_mat <- getX(fit)
+          sv2 <- svd(na.omit(L) , nu = 0, nv = NCOL(L))
+          rmv <- if (numDF == 0) 1:NCOL(L) else -(1:numDF)
+          constrainedX <- as.matrix(model_mat %*% sv2$v[ , rmv, drop=FALSE])
+          numCol <- NCOL(constrainedX)
+          names1 <- as.character(1:numCol)
+          names1 <- sapply(names1, function(x) paste0("XConCol", x))
+          newData <- data.frame(cbind(constrainedX, getData(fit)))
+          names(newData) <- c(names1, names(getData(fit)))
+          mlfit <- update(fit, method = "ML")
+          constrained_fit <- update(fit, fixed. = as.formula(paste0(". ~ ", paste(names1, collapse = "+"),  "- 1")), 
+                                    data = newData, method = "ML")
+          changeDF <- NCOL(L) - numDF
+          lrt_stat <- 2 * ( logLik(mlfit) - logLik(constrained_fit) )
+          if (lrt_stat < 0) warning("LRT stat is negative, original fit may have convergence problems.")
+          ret[[ii]]$anova[["changeDF"]] <- changeDF
+          ret[[ii]]$anova[["LRT ChiSq"]] <- lrt_stat
+          ret[[ii]]$anova[["LRT p-value"]] <- pchisq(lrt_stat, changeDF, lower.tail = FALSE)
+        
         } else {
           warning(paste0("LRT not yet tested with ", class(fit)))
         }
+      }
       
       ## Estimate
       
@@ -401,7 +422,7 @@ wald <-
 # Test
 if(FALSE){
 library(nlme)
-fit <- lme(mathach ~ ses * Sex * Sector, hs, random = ~ 1|school)
+fit <- lme(mathach ~ ses * Sex * Sector, hs, random = ~ 1 | school)
 summary(fit)
 pred <- expand.grid( ses = seq(-2,2,1), Sex = levels(hs$Sex), Sector = levels(hs$Sector))
 pred


### PR DESCRIPTION
Added in LRT = TRUE argument that also provides LRT test stat, change in DF, and p-value in wald() output.

NOTE: Currently only tested/compatible with "lm", "glm", "lme", "lmer", "lmerMod", "gls", "glmer", "glmerMod" objects. Wald still works for other objects but returns a message if LRT = TRUE (default) for any other objects.

relies on getData generic and some non-standard evaluation due to interesting challenges with the update() function and scoping. update() would not work inside this function without some modification of the inputs to update, as locally defined objects don't get sent through the pipeline to it's eventual evaluation. A new data frame is created to pass to update(), which includes defining every new column of the constrained model matrix as a separate named vector, and binding them all to the original fit's data frame (this couldn't be appended as a matrix for some reason).

For lme/gls objects, original model is refit with ML instead of REML to compare with constrained model.

If any refits throw an error, LRT is suppressed and only wald test is provided instead of function stopping, and an error message is provided.

For lmer/lmerMod/glmer/glmerMod objects, regular expressions extract the random effects from the formula and model is refit with ML instead of REML to compare with constrained model.

I also added in updated getFix and getData compatibility with the lme4 package.


