### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,8 @@ Imports: stats,
     naniar, 
     UpSetR, 
     MASS, 
-    Matrix
+    Matrix,
+    gplots
 Suggests: 
     knitr,
     rmarkdown,


### PR DESCRIPTION
I added gplots to the imports to solve an error message I've been getting. gplots isn't listed as a dependency in the current dev version of the package. 

```

> devtools::install_github("gmonette/spida2")
Downloading GitHub repo gmonette/spida2@HEAD
── R CMD build ───────────────────────────────────────────────────────────────────
✔  checking for file 'C:\Users\smaso\AppData\Local\Temp\RtmpUZs1T7\remotes7198486f329b\gmonette-spida2-a5d311f/DESCRIPTION' ...
─  preparing 'spida2': (1.2s)
✔  checking DESCRIPTION meta-information ...
─  checking for LF line-endings in source and make files and shell scripts
─  checking for empty or unneeded directories
     NB: this package now depends on R (>= 3.5.0)
     WARNING: Added dependency on R >= 3.5.0 because serialized objects in
     serialize/load version 3 cannot be read in older versions of R.
     File(s) containing such objects:
       'spida2/data/Florida_sentences.rda'
       'spida2/data/Florida_sentencing.rda' 'spida2/data/Unemp2.rda'
       'spida2/data/death.penalty.rda'
─  building 'spida2_0.2.1.tar.gz'
   
Installing package into ‘C:/Users/smaso/AppData/Local/R/win-library/4.3’
(as ‘lib’ is unspecified)
* installing *source* package 'spida2' ...
** using staged installation
** R
** data
*** moving datasets to lazyload DB
** byte-compile and prepare package for lazy loading
Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
  there is no package called 'gplots'
Calls: <Anonymous> ... loadNamespace -> withRestarts -> withOneRestart -> doWithOneRestart
Execution halted
ERROR: lazy loading failed for package 'spida2'
* removing 'C:/Users/smaso/AppData/Local/R/win-library/4.3/spida2'
Warning message:
In i.p(...) :
  installation of package ‘C:/Users/smaso/AppData/Local/Temp/RtmpUZs1T7/file719847006d46/spida2_0.2.1.tar.gz’ had non-zero exit status

```